### PR TITLE
fix(issue): prevent multiple deletion confirmation messages from bein…

### DIFF
--- a/js/controllers/issueManager.js
+++ b/js/controllers/issueManager.js
@@ -416,7 +416,38 @@ displayIssueBody= function(targetId){
  * @param {string} targetId - current test ID
  * @param {string} issueIndex - index of the issue to remove into an issue array
 */
-deleteConfirmationIssue = function (targetId, issueIndex) {
+const deleteConfirmationIssue = (targetId, issueIndex) => {
+    const feedbackId = `deleteIssueBtn-${targetId}-${issueIndex}-feedback`;
+    if (document.getElementById(feedbackId)) return;
+
+    const messageId = `deleteIssueMessage-${targetId}-${issueIndex}`;
+    const noButtonId = `btnDeleteIssueNo-${targetId}-${issueIndex}`;
+    const yesButtonId = `btnDeleteIssueYes-${targetId}-${issueIndex}`;
+
+    const htmlIssueFeedback = `
+        <div id="${feedbackId}">
+            <p id="${messageId}" class="mt-2 mb-0">${langVallydette.issueTxt3}</p>
+            <button type="button" 
+                id="${noButtonId}" 
+                class="btn btn-secondary btn-sm" 
+                aria-labelledby="${messageId} ${noButtonId}"
+                onClick="deleteIssue('${targetId}',${issueIndex}, false)">
+                ${langVallydette.no}
+            </button>
+            <button type="button" 
+                id="${yesButtonId}" 
+                class="btn btn-secondary btn-sm"
+                aria-labelledby="${messageId} ${yesButtonId}"
+                onClick="deleteIssue('${targetId}',${issueIndex}, true)">
+                ${langVallydette.yes}
+            </button>
+        </div>`;
+
+    document.getElementById(`deleteIssueBtn-${targetId}-${issueIndex}`)
+        .insertAdjacentHTML("afterend", htmlIssueFeedback);
+
+    document.getElementById(noButtonId).focus();
+}
 	const feedbackId = "deleteIssueBtn-" + targetId + "-" + issueIndex + "-feedback";
 	if (document.getElementById(feedbackId)) return
 

--- a/js/controllers/issueManager.js
+++ b/js/controllers/issueManager.js
@@ -417,7 +417,9 @@ displayIssueBody= function(targetId){
  * @param {string} issueIndex - index of the issue to remove into an issue array
 */
 deleteConfirmationIssue = function (targetId, issueIndex) {
-	
+	const feedbackId = "deleteIssueBtn-" + targetId + "-" + issueIndex + "-feedback";
+	if (document.getElementById(feedbackId)) return
+
 	let htmlIssueFeedback = '<div id="deleteIssueBtn-'+ targetId +'-'+ issueIndex +'-feedback">';
 	htmlIssueFeedback += '<span id="deleteIssueMessage-'+ targetId +'-'+ issueIndex +'">' + langVallydette.issueTxt3 + '</span>';
 	htmlIssueFeedback += '<button type="button" id="btnDeleteIssueNo-'+ targetId +'-'+ issueIndex +'" aria-labelledby="deleteIssueMessage-'+ targetId +'-'+ issueIndex +' btnDeleteIssueNo-'+ targetId +'-'+ issueIndex +'" class="btn btn-secondary btn-sm" onClick="deleteIssue(\''+ targetId +'\','+ issueIndex +', false)">' + langVallydette.no + '</button>';

--- a/js/controllers/issueManager.js
+++ b/js/controllers/issueManager.js
@@ -448,21 +448,6 @@ const deleteConfirmationIssue = (targetId, issueIndex) => {
 
     document.getElementById(noButtonId).focus();
 }
-	const feedbackId = "deleteIssueBtn-" + targetId + "-" + issueIndex + "-feedback";
-	if (document.getElementById(feedbackId)) return
-
-	let htmlIssueFeedback = '<div id="deleteIssueBtn-'+ targetId +'-'+ issueIndex +'-feedback">';
-	htmlIssueFeedback += '<span id="deleteIssueMessage-'+ targetId +'-'+ issueIndex +'">' + langVallydette.issueTxt3 + '</span>';
-	htmlIssueFeedback += '<button type="button" id="btnDeleteIssueNo-'+ targetId +'-'+ issueIndex +'" aria-labelledby="deleteIssueMessage-'+ targetId +'-'+ issueIndex +' btnDeleteIssueNo-'+ targetId +'-'+ issueIndex +'" class="btn btn-secondary btn-sm" onClick="deleteIssue(\''+ targetId +'\','+ issueIndex +', false)">' + langVallydette.no + '</button>';
-	htmlIssueFeedback += '<button type="button" id="btnDeleteIssueYes-'+ targetId +'-'+ issueIndex +'" class="btn btn-secondary btn-sm"  aria-labelledby="deleteIssueMessage-'+ targetId +'-'+ issueIndex +' btnDeleteIssueYes-'+ targetId +'-'+ issueIndex +'"  onClick="deleteIssue(\''+ targetId +'\','+ issueIndex +', true)">' + langVallydette.yes + '</button>';
-	htmlIssueFeedback += '</div>';
-	
-	let elButton = document.getElementById("deleteIssueBtn-"+ targetId +"-"+ issueIndex);
-	elButton.insertAdjacentHTML("afterend", htmlIssueFeedback); 
-	
-	document.getElementById("btnDeleteIssueNo-"+ targetId +"-"+ issueIndex).focus();
-	
-}
 
 /**
  * Delete an issue from the vallydette object.


### PR DESCRIPTION
This pull request includes a small change to the `js/controllers/issueManager.js` file. The change ensures that the feedback element is not duplicated by checking for its existence before creating a new one.

* [`js/controllers/issueManager.js`](diffhunk://#diff-3173fb89e9a6dc2819239b540beae0e6d27fbc4809a92db06b9304542e7ab142R420-R421): Added a check to prevent duplicate feedback elements in the `deleteConfirmationIssue` function.

<img width="727" alt="image" src="https://github.com/user-attachments/assets/09c04dba-b3e6-4005-b7f2-4c74be5aac56" />
