### PR TITLE
Fix typo in testID-013

### DIFF
--- a/json/criteres-wcag-ease-fr.json
+++ b/json/criteres-wcag-ease-fr.json
@@ -360,7 +360,7 @@
 	},
 	{
 		"themes": "Contenu non-textuel",
-		"title": "Les images possédent-elles un texte de remplacement pertinent&nbsp;?",
+		"title": "Les images possèdent-elles un texte de remplacement pertinent&nbsp;?",
 		"ID": "testID-013",
 		"IDorigin": "testID-013",
 		"wcag": [


### PR DESCRIPTION
testID-013 (french version):

> Les images poss**é**dent-elles un texte de remplacement pertinent&nbsp;?

should be:

> Les images poss**è**dent-elles un texte de remplacement pertinent&nbsp;?