### PR TITLE
[Fix] testID-007 not liked to correct WCAG criterion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,15 @@ All notable changes to this project will be documented in this file. This projec
 
 ---
 
-## [3.0.3] – 2026-09-13
+## [3.0.4] – 2026-08-04
+
+### Fixed
+
+- [Les messages d'erreur et les suggestions sont-ils explicites ?](https://la-va11ydette.orange.com/?list=wcag-web&lang=fr#headingtestID-007) was linked to **3.3.1 A** instead of **3.3.3 AA**.
+
+---
+
+## [3.0.3] – 2026-09-03
 
 ### Changed
 

--- a/json/criteres-wcag-ease-fr.json
+++ b/json/criteres-wcag-ease-fr.json
@@ -102,7 +102,7 @@
 		"ID": "testID-007",
 		"IDorigin": "testID-007",
 		"wcag": [
-			"3.3.1 A"
+			"3.3.3 AA"
 		],
 		"verifier": "<p>Vérifier que&nbsp;:</p><ul><li>Les messages d'erreur énoncent clairement la nature de l'erreur (exemple&nbsp;: champ téléphone obligatoire, format de l'email invalide…).</li><li>Et que, si besoin, les suggestions de correction aident à la correction des erreurs.</li></ul>",
 		"exception": "Le critère est non applicable lorsqu'il est impossible de faire une suggestion ou que l'on ne peut donner de suggestion pour des raisons de sécurité ou parce qu'il s'agit d'une fonctionnalité essentielle.",


### PR DESCRIPTION
[Les messages d'erreur et les suggestions sont-ils explicites ?](https://la-va11ydette.orange.com/?list=wcag-web&lang=fr#headingtestID-007) was linked to **3.3.1 A** instead of **3.3.3 AA**.