### PR TITLE
[Fix] Computation of global compliance rate

### DIFF
--- a/js/controllers/computationManager.js
+++ b/js/controllers/computationManager.js
@@ -520,22 +520,22 @@ function dataWCAGComputation() {
 		}
 
 		/** Adds the results to the WCAG object. */
-		dataWCAG.conformeA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === true).length;
-		dataWCAG.conformeAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === true).length;
-		dataWCAG.nonconformeA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === false).length;
-		dataWCAG.nonconformeAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === false).length;
-		dataWCAG.naA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === "na").length;
-		dataWCAG.naAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === "na").length;
+		dataWCAG.conformeA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === true && item.deprecated !== true).length;
+		dataWCAG.conformeAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === true && item.deprecated !== true).length;
+		dataWCAG.nonconformeA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === false && item.deprecated !== true).length;
+		dataWCAG.nonconformeAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === false && item.deprecated !== true).length;
+		dataWCAG.naA = dataWCAG.items.filter(item => item.level ==="A" && item.resultat === "na" && item.deprecated !== true).length;
+		dataWCAG.naAA = dataWCAG.items.filter(item => item.level ==="AA" && item.resultat === "na" && item.deprecated !== true).length;
 		dataWCAG.totalconforme = dataWCAG.conformeA + dataWCAG.conformeAA;
 		dataWCAG.totalnonconforme = dataWCAG.nonconformeA + dataWCAG.nonconformeAA;
 
-		dataWCAG.totalA = dataWCAG.items.filter(function(item){return item.level==="A"}).length;
-		dataWCAG.totalAA = dataWCAG.items.filter(function(item){return item.level==="AA"}).length;
+		dataWCAG.totalA = dataWCAG.items.filter(function(item){return item.level==="A" && item.deprecated !== true}).length;
+		dataWCAG.totalAA = dataWCAG.items.filter(function(item){return item.level==="AA" && item.deprecated !== true}).length;
 
-		dataWCAG.nbTotalWcag = dataWCAG.items.filter(item => (item.resultat === true || item.resultat === false) && item.level!=="AAA").length;
-		dataWCAG.nbTrueWcag = dataWCAG.items.filter(item => item.resultat === true && item.level!=="AAA").length;
-		dataWCAG.nbFalseWcag = dataWCAG.items.filter(item => item.resultat === false && item.level!=="AAA").length;
-		dataWCAG.nbNaWcag = dataWCAG.items.filter(item => item.resultat === "na" && item.level!=="AAA").length;
+		dataWCAG.nbTotalWcag = dataWCAG.items.filter(item => (item.resultat === true || item.resultat === false) && item.level!=="AAA" && item.deprecated !== true).length;
+		dataWCAG.nbTrueWcag = dataWCAG.items.filter(item => item.resultat === true && item.level!=="AAA" && item.deprecated !== true).length;
+		dataWCAG.nbFalseWcag = dataWCAG.items.filter(item => item.resultat === false && item.level!=="AAA" && item.deprecated !== true).length;
+		dataWCAG.nbNaWcag = dataWCAG.items.filter(item => item.resultat === "na" && item.level!=="AAA" && item.deprecated !== true).length;
 
 		/**
 		* 	If all the wcag are non-applicables (hypothetical but tested)


### PR DESCRIPTION
**Please note that this PR is related to the computation of the global compliance rate and is therefore highly sensitive.**
**Therefore, it needs extensive testing and a thorough review before merging.**

Closes #311 

In the 'Compliance' page and 'Summary by levels' we now have:
<img width="960" height="172" alt="image" src="https://github.com/user-attachments/assets/902fe4c2-d50a-4b4a-9e4c-1dc0774f0c1e" />

The obsolete criterion SC 4.1.1 is no longer taken into account and we have now 31A and 24AA for a total of 55 criteria.

I am just wondering if the beginning of the solution is useful or more like an overkill? Since computation of global compliance relies on applicable criteria only, it may not be really usefull to exclude deprecated criterion? However it may be a good fallback to prevent any edge case? 🤔 