### PR TITLE
fix(a11y): Links contrast on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,18 @@
+:root, [class*=bg-]:not([class*=bg-black],[class*=-dark]:not(.border-dark):not(.text-dark):not(.btn-dark):not(.focus-ring-dark):not(.link-underline-dark):not(.link-dark),[class*=bg-secondary]):not(.bg-transparent) {
+  --bs-primary: #f15e00;
+  --bs-primary-rgb: 241, 94, 0;
+  --bs-primary-bg-subtle: #f15e00;
+  --bs-primary-border-subtle: #f15e00;
+  --bs-primary-text-emphasis: #f15e00;
+  --bs-link-hover-color: #000000;
+  --bs-link-hover-color-rgb: 0, 0, 0;
+}
+
+a:hover {
+  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+  text-decoration-color: var(--bs-primary);
+  text-decoration-thickness: .2em;
+}
 
 /* Title */
     .card-title,


### PR DESCRIPTION
Closes #301 

I applied the same hover styles for links as seen on https://a11y-guidelines.orange.com/en/.
I adjusted them slightly because the version of Boosted is a bit older (prior to the implementation of the color theme).